### PR TITLE
Fix proteinmpnn_fastrelax.yml

### DIFF
--- a/include/proteinmpnn_fastrelax.yml
+++ b/include/proteinmpnn_fastrelax.yml
@@ -1,7 +1,5 @@
 name: proteinmpnn_binder_design
 channels:
-  - pytorch
-  - nvidia
   - conda-forge
   - https://conda.rosettacommons.org
 
@@ -12,4 +10,3 @@ dependencies:
   - ml-collections
   - pyrosetta
   - numpy<2.0
-  - mkl=2024.0


### PR DESCRIPTION
Removed nvidia and pytorch channels that were resulting in multiple versions of openmp library being installed. Since we are only using CPUs for this container, we do not need NVIDIA libraries anyway.

The MKL version pin was done as a workaround and can be removed now that the python packages are consistent.