### PR TITLE
Fix: Explicitly blocks MKL installation and uses Openblas instead

### DIFF
--- a/include/proteinmpnn_fastrelax.yml
+++ b/include/proteinmpnn_fastrelax.yml
@@ -10,3 +10,5 @@ dependencies:
   - ml-collections
   - pyrosetta
   - numpy<2.0
+  - nomkl
+  - openblas


### PR DESCRIPTION
The first patch did not fix the bug with MPNN-FastRelax, I have now switched to using openblas explicitly